### PR TITLE
Remove CMD from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,3 @@ RUN apk --no-cache add python3 && pip3 install -U pip && \
    yes | pip3 uninstall pip && rm -f requirements.txt
 COPY alias /root/.aws/cli/alias
 ENTRYPOINT ["/usr/bin/aws"]
-CMD ["/bin/sh"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Remove `CMD` from Dockerfile

## Related Issue
Fixes https://github.com/LanikSJ/awscli-aliases/issues/42

## Motivation and Context
AWS CLI doesn't run as a daemon.

## How Has This Been Tested?
Travis CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
