### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,4 +1,6 @@
 name: Code Coverage
+permissions:
+  contents: read
 
 on: 
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/awscli-aliases/security/code-scanning/13](https://github.com/LanikSJ/awscli-aliases/security/code-scanning/13)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions granted to the workflow. Based on the tasks performed in the workflow (checking out code, installing dependencies, and generating coverage), the workflow only requires `contents: read` permissions. This ensures that the workflow adheres to the principle of least privilege.

The `permissions` block should be added immediately after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
