### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,5 +1,9 @@
 name: Update License
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 10 1 1 *' # 10:00 AM on January 1


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/awscli-aliases/security/code-scanning/16](https://github.com/LanikSJ/awscli-aliases/security/code-scanning/16)

To fix the issue, add a `permissions` block at the root of the workflow file to define the minimal permissions required. Based on the workflow's functionality:
- The `contents: read` permission is needed to check out the repository.
- The `pull-requests: write` permission is required to create and merge pull requests.

This ensures the workflow has only the permissions it needs and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
