### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,4 +1,7 @@
 name: Restyled
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/awscli-aliases/security/code-scanning/18](https://github.com/LanikSJ/awscli-aliases/security/code-scanning/18)

To fix the problem, add a `permissions` block to the workflow file. This block should be placed at the top level (applies to all jobs) or at the job level (for more granular control). The minimal permissions required should be specified. For this workflow, the jobs interact with pull requests and upload artifacts, so at a minimum, `contents: read` and `pull-requests: write` are likely needed. If artifact upload requires additional permissions, those can be added, but for most cases, `contents: read` and `pull-requests: write` suffice. The `permissions` block should be added after the `name` field and before the `on` field for workflow-wide effect.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
