### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,4 +1,7 @@
 name: Restyled
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/awscli-aliases/security/code-scanning/17](https://github.com/LanikSJ/awscli-aliases/security/code-scanning/17)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/restyled.yml`. The block can be added at the top level (applies to all jobs) or at the job level (for more granular control). The minimal starting point is `contents: read`, but jobs that need to write to pull requests (such as the cleanup job) may require additional permissions like `pull-requests: write`. For this workflow, adding a top-level `permissions` block with `contents: read` and `pull-requests: write` is the safest approach, as it covers the needs of all jobs without being overly permissive. The block should be added after the `name:` and before the `on:` section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
