### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,4 +1,6 @@
 name: Restyled
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -53,6 +55,9 @@ jobs:
   # On closed events clean up any leftover Restyled PRs
   restyled-cleanup:
     if: ${{ github.event.action == 'closed' }}
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: restyled-io/actions/setup@v4


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/awscli-aliases/security/code-scanning/15](https://github.com/LanikSJ/awscli-aliases/security/code-scanning/15)

To fix the problem, add a `permissions` block to the workflow. The best way is to set the minimal required permissions at the root level, which will apply to all jobs unless overridden. For this workflow, most jobs only need `contents: read`, but the `restyled-cleanup` job needs to close PRs and delete branches, which requires `pull-requests: write` and possibly `contents: write`. Therefore, set `permissions: contents: read` at the root, and override it for the `restyled-cleanup` job with `permissions: contents: write, pull-requests: write`. This change should be made in `.github/workflows/restyled.yml` at the top level and within the `restyled-cleanup` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
